### PR TITLE
add BusyAgentPercentage metric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM alpine:3.8
+FROM golang:1.12 as builder
+WORKDIR /go/src/github.com/buildkite/buildkite-agent-metrics/
+COPY . .
+RUN GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o buildkite-agent-metrics .
+
+FROM alpine:3.9
 RUN apk update && apk add curl ca-certificates
-COPY bin/buildkite-agent-metrics /usr/local/bin/
+COPY --from=builder /go/src/github.com/buildkite/buildkite-agent-metrics/buildkite-agent-metrics .
 EXPOSE 8080 8125
-ENTRYPOINT ["/usr/local/bin/buildkite-agent-metrics"]
+ENTRYPOINT ["./buildkite-agent-metrics"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.8
+RUN apk update && apk add curl ca-certificates
+COPY bin/buildkite-agent-metrics /usr/local/bin/
+EXPOSE 8080 8125
+ENTRYPOINT ["/usr/local/bin/buildkite-agent-metrics"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ aws lambda create-function \
 You can build a docker image for the `buildkite-agent-metrics` following:
 
 ```
-GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o bin/buildkite-agent-metrics .
 docker build -t buildkite-agent-metrics .
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,19 +97,19 @@ Currently this will publish metrics to Cloudwatch under the custom metric prefix
 The following metrics are gathered when no specific queue is supplied:
 
 ```
-Buildkite > RunningJobsCount
-Buildkite > ScheduledJobsCount
-Buildkite > UnfinishedJobsCount
-Buildkite > IdleAgentsCount
-Buildkite > BusyAgentsCount
-Buildkite > TotalAgentsCount
+Buildkite > (Org) > RunningJobsCount
+Buildkite > (Org) > ScheduledJobsCount
+Buildkite > (Org) > UnfinishedJobsCount
+Buildkite > (Org) > IdleAgentsCount
+Buildkite > (Org) > BusyAgentsCount
+Buildkite > (Org) > TotalAgentsCount
 
-Buildkite > (Queue) > RunningJobsCount
-Buildkite > (Queue) > ScheduledJobsCount
-Buildkite > (Queue) > UnfinishedJobsCount
-Buildkite > (Queue) > IdleAgentsCount
-Buildkite > (Queue) > BusyAgentsCount
-Buildkite > (Queue) > TotalAgentsCount
+Buildkite > (Org, Queue) > RunningJobsCount
+Buildkite > (Org, Queue) > ScheduledJobsCount
+Buildkite > (Org, Queue) > UnfinishedJobsCount
+Buildkite > (Org, Queue) > IdleAgentsCount
+Buildkite > (Org, Queue) > BusyAgentsCount
+Buildkite > (Org, Queue) > TotalAgentsCount
 ```
 
 When a queue is specified, only that queue's metrics are published.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ aws lambda create-function \
   --handler handler
 ```
 
+### Running as a Container
+
+You can build a docker image for the `buildkite-agent-metrics` following:
+
+```
+GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o bin/buildkite-agent-metrics .
+docker build -t buildkite-agent-metrics .
+```
+
+This will create a local docker image named as `buildkite-agent-metrics` that you can tag and push to your own registry.
+
+You can use the command-line arguments in a docker execution in the same way as described before:
+
+```
+docker run --rm buildkite-agent-metrics -token abc123 -interval 30s -queue my-queue
+```
+
 ### Backends
 
 By default metrics will be submitted to CloudWatch but the backend can be switched to StatsD or Prometheus using the command-line argument `-backend statsd` or `-backend prometheus` respectively.

--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -68,15 +68,9 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 			})
 		}
 
-		// Add the queue first
+		// Add the queue and org dimensions
 		dimensions = append(dimensions,
 			&cloudwatch.Dimension{Name: aws.String("Queue"), Value: aws.String(name)},
-		)
-
-		metrics = append(metrics, cloudwatchMetrics(c, dimensions)...)
-
-		// Then the queue + the org
-		dimensions = append(dimensions,
 			&cloudwatch.Dimension{Name: aws.String("Org"), Value: aws.String(r.Org)},
 		)
 

--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -61,7 +61,6 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 	}
 
 	svc := cloudwatch.New(sess)
-]
 	for _, d := range cb.dimensions {
 		log.Printf("Using custom Cloudwatch dimension of [ %s = %s ]", d.Key, d.Value)
 	}

--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -40,17 +40,28 @@ func ParseCloudWatchDimensions(ds string) ([]CloudWatchDimension, error) {
 
 // CloudWatchBackend sends metrics to AWS CloudWatch
 type CloudWatchBackend struct {
+	region     string
 	dimensions []CloudWatchDimension
 }
 
 // NewCloudWatchBackend returns a new CloudWatchBackend with optional dimensions
-func NewCloudWatchBackend(dimensions []CloudWatchDimension) *CloudWatchBackend {
-	return &CloudWatchBackend{dimensions: dimensions}
+func NewCloudWatchBackend(region string, dimensions []CloudWatchDimension) *CloudWatchBackend {
+	return &CloudWatchBackend{
+		region:     region,
+		dimensions: dimensions,
+	}
 }
 
 func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
-	svc := cloudwatch.New(session.New())
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(cb.region),
+	})
+	if err != nil {
+		return err
+	}
 
+	svc := cloudwatch.New(sess)
+]
 	for _, d := range cb.dimensions {
 		log.Printf("Using custom Cloudwatch dimension of [ %s = %s ]", d.Key, d.Value)
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -17,6 +17,7 @@ const (
 	IdleAgentCount      = "IdleAgentCount"
 	BusyAgentCount      = "BusyAgentCount"
 	TotalAgentCount     = "TotalAgentCount"
+	BusyAgentPercentage = "BusyAgentPercentage"
 )
 
 type Collector struct {
@@ -138,6 +139,7 @@ func (c *Collector) Collect() (*Result, error) {
 		result.Totals[IdleAgentCount] = allMetrics.Agents.Idle
 		result.Totals[BusyAgentCount] = allMetrics.Agents.Busy
 		result.Totals[TotalAgentCount] = allMetrics.Agents.Total
+		result.Totals[BusyAgentPercentage] = busyAgentPercentage(allMetrics.Agents.metricsAgentsResponse)
 
 		for queueName, queueJobMetrics := range allMetrics.Jobs.Queues {
 			if _, ok := result.Queues[queueName]; !ok {
@@ -155,6 +157,7 @@ func (c *Collector) Collect() (*Result, error) {
 			result.Queues[queueName][IdleAgentCount] = queueAgentMetrics.Idle
 			result.Queues[queueName][BusyAgentCount] = queueAgentMetrics.Busy
 			result.Queues[queueName][TotalAgentCount] = queueAgentMetrics.Total
+			result.Queues[queueName][BusyAgentPercentage] = busyAgentPercentage(queueAgentMetrics)
 		}
 	} else {
 		log.Printf("Collecting agent metrics for queue '%s'", c.Queue)
@@ -213,6 +216,7 @@ func (c *Collector) Collect() (*Result, error) {
 			IdleAgentCount:      queueMetrics.Agents.Idle,
 			BusyAgentCount:      queueMetrics.Agents.Busy,
 			TotalAgentCount:     queueMetrics.Agents.Total,
+			BusyAgentPercentage: busyAgentPercentage(queueMetrics.Agents),
 		}
 	}
 
@@ -221,6 +225,13 @@ func (c *Collector) Collect() (*Result, error) {
 	}
 
 	return result, nil
+}
+
+func busyAgentPercentage(agents metricsAgentsResponse) int {
+	if agents.Total > 0 {
+		return int(100 * agents.Busy / agents.Total)
+	}
+	return 0
 }
 
 func (r Result) Dump() {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -15,6 +15,7 @@ const (
 	ScheduledJobsCount  = "ScheduledJobsCount"
 	RunningJobsCount    = "RunningJobsCount"
 	UnfinishedJobsCount = "UnfinishedJobsCount"
+	WaitingJobsCount    = "WaitingJobsCount"
 	IdleAgentCount      = "IdleAgentCount"
 	BusyAgentCount      = "BusyAgentCount"
 	TotalAgentCount     = "TotalAgentCount"
@@ -52,6 +53,7 @@ type metricsAgentsResponse struct {
 type metricsJobsResponse struct {
 	Scheduled int `json:"scheduled"`
 	Running   int `json:"running"`
+	Waiting   int `json:"waiting"`
 	Total     int `json:"total"`
 }
 
@@ -150,6 +152,7 @@ func (c *Collector) Collect() (*Result, error) {
 		result.Totals[ScheduledJobsCount] = allMetrics.Jobs.Scheduled
 		result.Totals[RunningJobsCount] = allMetrics.Jobs.Running
 		result.Totals[UnfinishedJobsCount] = allMetrics.Jobs.Total
+		result.Totals[WaitingJobsCount] = allMetrics.Jobs.Waiting
 		result.Totals[IdleAgentCount] = allMetrics.Agents.Idle
 		result.Totals[BusyAgentCount] = allMetrics.Agents.Busy
 		result.Totals[TotalAgentCount] = allMetrics.Agents.Total
@@ -161,6 +164,7 @@ func (c *Collector) Collect() (*Result, error) {
 			result.Queues[queueName][ScheduledJobsCount] = queueJobMetrics.Scheduled
 			result.Queues[queueName][RunningJobsCount] = queueJobMetrics.Running
 			result.Queues[queueName][UnfinishedJobsCount] = queueJobMetrics.Total
+			result.Queues[queueName][WaitingJobsCount] = queueJobMetrics.Waiting
 		}
 
 		for queueName, queueAgentMetrics := range allMetrics.Agents.Queues {
@@ -225,6 +229,7 @@ func (c *Collector) Collect() (*Result, error) {
 			ScheduledJobsCount:  queueMetrics.Jobs.Scheduled,
 			RunningJobsCount:    queueMetrics.Jobs.Running,
 			UnfinishedJobsCount: queueMetrics.Jobs.Total,
+			WaitingJobsCount:    queueMetrics.Jobs.Waiting,
 			IdleAgentCount:      queueMetrics.Agents.Idle,
 			BusyAgentCount:      queueMetrics.Agents.Busy,
 			TotalAgentCount:     queueMetrics.Agents.Total,

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -12,7 +12,7 @@ func TestCollectorWithEmptyResponseForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{}`)
+			io.WriteString(w, `{"organization": {"slug": "org-name"}}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -38,6 +38,7 @@ func TestCollectorWithEmptyResponseForAllQueues(t *testing.T) {
 		{"Totals", res.Totals, TotalAgentCount, 0},
 		{"Totals", res.Totals, BusyAgentCount, 0},
 		{"Totals", res.Totals, IdleAgentCount, 0},
+		{"Totals", res.Totals, BusyAgentPercentage, 0},
 	}
 
 	for _, tc := range testCases {
@@ -57,7 +58,7 @@ func TestCollectorWithNoJobsForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":0,"running":0,"all":0,"queues":{}},"agents":{"idle":0,"busy":0,"all":0,"queues":{}}}`)
+			io.WriteString(w, `{"organization": {"slug": "org-name"}, "jobs":{"scheduled":0,"running":0,"all":0,"queues":{}},"agents":{"idle":0,"busy":0,"all":0,"queues":{}}}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -83,6 +84,7 @@ func TestCollectorWithNoJobsForAllQueues(t *testing.T) {
 		{"Totals", res.Totals, TotalAgentCount, 0},
 		{"Totals", res.Totals, BusyAgentCount, 0},
 		{"Totals", res.Totals, IdleAgentCount, 0},
+		{"Totals", res.Totals, BusyAgentPercentage, 0},
 	}
 
 	for _, tc := range testCases {
@@ -102,7 +104,7 @@ func TestCollectorWithSomeJobsAndAgentsForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":3,"running":1,"total":4,"queues":{"default":{"scheduled":2,"running":1,"total":3},"deploy":{"scheduled":1,"running":0,"total":1}}},"agents":{"idle":0,"busy":1,"total":1,"queues":{"default":{"idle":0,"busy":1,"total":1}}}}`)
+			io.WriteString(w, `{"organization": {"slug": "org-name"}, "jobs":{"scheduled":3,"running":1,"total":4,"queues":{"default":{"scheduled":2,"running":1,"total":3},"deploy":{"scheduled":1,"running":0,"total":1}}},"agents":{"idle":0,"busy":1,"total":1,"queues":{"default":{"idle":0,"busy":1,"total":1}}}}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -128,6 +130,7 @@ func TestCollectorWithSomeJobsAndAgentsForAllQueues(t *testing.T) {
 		{"Totals", res.Totals, TotalAgentCount, 1},
 		{"Totals", res.Totals, BusyAgentCount, 1},
 		{"Totals", res.Totals, IdleAgentCount, 0},
+		{"Totals", res.Totals, BusyAgentPercentage, 100},
 
 		{"Queue.default", res.Queues["default"], RunningJobsCount, 1},
 		{"Queue.default", res.Queues["default"], ScheduledJobsCount, 2},
@@ -166,7 +169,7 @@ func TestCollectorWithSomeJobsAndAgentsForAQueue(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics/queue" && r.URL.Query().Get("name") == "deploy" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":3,"running":1,"total":4},"agents":{"idle":0,"busy":1,"total":1}}`)
+			io.WriteString(w, `{"organization": {"slug": "org-name"}, "jobs":{"scheduled":3,"running":1,"total":4},"agents":{"idle":0,"busy":1,"total":1}}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -196,6 +199,7 @@ func TestCollectorWithSomeJobsAndAgentsForAQueue(t *testing.T) {
 		{"Queue.deploy", res.Queues["deploy"], TotalAgentCount, 1},
 		{"Queue.deploy", res.Queues["deploy"], BusyAgentCount, 1},
 		{"Queue.deploy", res.Queues["deploy"], IdleAgentCount, 0},
+		{"Queue.deploy", res.Queues["deploy"], BusyAgentPercentage, 100},
 	}
 
 	for _, tc := range testCases {

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -12,14 +12,20 @@ func TestCollectorWithEmptyResponseForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{}`)
+			_, _ = io.WriteString(w, `{
+				"organization": {
+					"slug": "test"
+				},
+				"jobs": {},
+				"agents": {}
+			}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	c := &Collector{
-		Endpoint: s.URL,
-		Token: "abc123",
+		Endpoint:  s.URL,
+		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",
 	}
 	res, err := c.Collect()
@@ -57,14 +63,30 @@ func TestCollectorWithNoJobsForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":0,"running":0,"all":0,"queues":{}},"agents":{"idle":0,"busy":0,"all":0,"queues":{}}}`)
+			_, _ = io.WriteString(w, `{
+				"organization": {
+				  "slug": "test"
+				},
+				"jobs": {
+				  "scheduled": 0,
+				  "running": 0,
+				  "total": 0,
+				  "queues": {}
+				},
+				"agents": {
+				  "idle": 0,
+				  "busy": 0,
+				  "total": 0,
+				  "queues": {}
+				}
+			  }`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	c := &Collector{
-		Endpoint: s.URL,
-		Token: "abc123",
+		Endpoint:  s.URL,
+		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",
 	}
 	res, err := c.Collect()
@@ -102,14 +124,47 @@ func TestCollectorWithSomeJobsAndAgentsForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":3,"running":1,"total":4,"queues":{"default":{"scheduled":2,"running":1,"total":3},"deploy":{"scheduled":1,"running":0,"total":1}}},"agents":{"idle":0,"busy":1,"total":1,"queues":{"default":{"idle":0,"busy":1,"total":1}}}}`)
+			_, _ = io.WriteString(w, `{
+				"organization": {
+				  "slug": "test"
+				},
+				"jobs": {
+				  "scheduled": 3,
+				  "running": 1,
+				  "total": 4,
+				  "queues": {
+					"default": {
+					  "scheduled": 2,
+					  "running": 1,
+					  "total": 3
+					},
+					"deploy": {
+					  "scheduled": 1,
+					  "running": 0,
+					  "total": 1
+					}
+				  }
+				},
+				"agents": {
+				  "idle": 0,
+				  "busy": 1,
+				  "total": 1,
+				  "queues": {
+					"default": {
+					  "idle": 0,
+					  "busy": 1,
+					  "total": 1
+					}
+				  }
+				}
+			  }`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	c := &Collector{
-		Endpoint: s.URL,
-		Token: "abc123",
+		Endpoint:  s.URL,
+		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",
 	}
 	res, err := c.Collect()
@@ -166,16 +221,30 @@ func TestCollectorWithSomeJobsAndAgentsForAQueue(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics/queue" && r.URL.Query().Get("name") == "deploy" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":3,"running":1,"total":4},"agents":{"idle":0,"busy":1,"total":1}}`)
+			_, _ = io.WriteString(w, `{
+				"organization": {
+				  "slug": "test"
+				},
+				"jobs": {
+				  "scheduled": 3,
+				  "running": 1,
+				  "total": 4
+				},
+				"agents": {
+				  "idle": 0,
+				  "busy": 1,
+				  "total": 1
+				}
+			  }`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	c := &Collector{
-		Endpoint: s.URL,
-		Token: "abc123",
+		Endpoint:  s.URL,
+		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",
-		Queue: "deploy",
+		Queue:     "deploy",
 	}
 	res, err := c.Collect()
 	if err != nil {

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -33,6 +33,7 @@ func main() {
 
 func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	token := os.Getenv("BUILDKITE_AGENT_TOKEN")
+	awsRegion := os.Getenv("AWS_REGION")
 	ssmTokenKey := os.Getenv("BUILDKITE_AGENT_TOKEN_SSM_KEY")
 	backendOpt := os.Getenv("BUILDKITE_BACKEND")
 	queue := os.Getenv("BUILDKITE_QUEUE")
@@ -82,7 +83,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		b = backend.NewCloudWatchBackend(dimensions)
+		b = backend.NewCloudWatchBackend(awsRegion, dimensions)
 	}
 
 	res, err := c.Collect()

--- a/main.go
+++ b/main.go
@@ -119,13 +119,16 @@ func main() {
 
 	if *interval > 0 {
 		for {
-			// Respect the min poll duration returned by
-			// the API
-			if *interval > minPollDuration {
-				time.Sleep(minPollDuration)
-			} else {
-				time.Sleep(*interval)
+			waitTime := *interval
+
+			// Respect the min poll duration returned by the API
+			if *interval < minPollDuration {
+				log.Printf("Increasing poll duration based on rate-limit headers")
+				waitTime = minPollDuration
 			}
+
+			log.Printf("Waiting for %v (minimum of %v)", waitTime, minPollDuration)
+			time.Sleep(waitTime)
 
 			minPollDuration, err = f()
 			if err != nil {


### PR DESCRIPTION
adding `AgentUsagePercentage` metric, which will be useful in order to implement target tracking autoscaling, see: https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-target-tracking.html

Also fixed unit tests which were failing with
```
=== RUN   TestCollectorWithNoJobsForAllQueues
2019/03/28 12:10:03 Collecting agent metrics for all queues
--- FAIL: TestCollectorWithNoJobsForAllQueues (0.00s)
    collector_test.go:72: No organization slug was found in the metrics response
```